### PR TITLE
Fix concurrency race, add SSE streaming, O(N) sanitize, model polling

### DIFF
--- a/apps/server/src/routes_chat.cpp
+++ b/apps/server/src/routes_chat.cpp
@@ -2,6 +2,8 @@
 
 #include <drogon/drogon.h>
 
+#include <thread>
+
 #include "api_parsers.hpp"
 #include "http_helpers.hpp"
 
@@ -50,6 +52,92 @@ void register_chat_routes(RuntimeState &runtime_state) {
 
         auto resp = drogon::HttpResponse::newHttpResponse();
         write_json(req, resp, body);
+        cb(resp);
+      },
+      {drogon::Post});
+
+  drogon::app().registerHandler(
+      "/api/chat/stream",
+      [&runtime_state](const drogon::HttpRequestPtr &req,
+                       std::function<void(const drogon::HttpResponsePtr &)> &&cb) {
+        std::string message;
+        Json::Value details(Json::objectValue);
+        if (const auto parse_error =
+                parse_chat_complete_request(req->getJsonObject(), message, details);
+            parse_error.has_value()) {
+          write_error(req, std::move(cb), drogon::k400BadRequest, "APP-VAL-001",
+                      "validation", *parse_error, false, details);
+          return;
+        }
+
+        const auto cid = resolve_correlation_id(req);
+
+        auto resp = drogon::HttpResponse::newAsyncStreamResponse(
+            [&runtime_state, message = std::move(message)](
+                drogon::ResponseStreamPtr stream) mutable {
+              // Move the unique_ptr into shared ownership so the inference thread
+              // and token callback can safely call send() without holding the
+              // unique_ptr exclusively.
+              auto ss = std::shared_ptr<drogon::ResponseStream>(std::move(stream));
+
+              std::thread([&runtime_state, msg = std::move(message),
+                           ss = std::move(ss)]() mutable {
+                auto token_cb = [&ss](std::string_view token) {
+                  Json::Value event(Json::objectValue);
+                  event["type"] = "token";
+                  event["content"] = std::string(token);
+                  Json::StreamWriterBuilder builder;
+                  builder["indentation"] = "";
+                  ss->send("data: " + Json::writeString(builder, event) + "\n\n");
+                };
+
+                std::string error_code;
+                std::string error_message;
+                const auto result = runtime_state.chat_stream(
+                    msg, std::move(token_cb), error_code, error_message);
+
+                if (!result) {
+                  Json::Value err(Json::objectValue);
+                  err["type"] = "error";
+                  err["code"] = error_code;
+                  err["message"] = error_message;
+                  Json::StreamWriterBuilder builder;
+                  builder["indentation"] = "";
+                  ss->send("data: " + Json::writeString(builder, err) + "\n\n");
+                  ss->close();
+                  return;
+                }
+
+                Json::Value usage(Json::objectValue);
+                usage["prompt_tokens"] = result->usage.prompt_tokens;
+                usage["completion_tokens"] = result->usage.completion_tokens;
+                usage["total_tokens"] = result->usage.total_tokens;
+
+                Json::Value metrics(Json::objectValue);
+                metrics["latency_ms"] =
+                    static_cast<Json::Int64>(result->metrics.latency_ms.count());
+                metrics["time_to_first_token_ms"] = static_cast<Json::Int64>(
+                    result->metrics.time_to_first_token_ms.count());
+                metrics["tokens_per_second"] = result->metrics.tokens_per_second;
+
+                Json::Value done(Json::objectValue);
+                done["type"] = "done";
+                done["text"] = result->text;
+                done["usage"] = usage;
+                done["metrics"] = metrics;
+
+                Json::StreamWriterBuilder builder;
+                builder["indentation"] = "";
+                ss->send("data: " + Json::writeString(builder, done) + "\n\n");
+                ss->close();
+              }).detach();
+            },
+            /*disableKickoffTimeout=*/true);
+
+        resp->setContentTypeString("text/event-stream");
+        resp->addHeader("Cache-Control", "no-cache");
+        resp->addHeader("X-Accel-Buffering", "no");
+        resp->addHeader("X-Correlation-Id", cid);
         cb(resp);
       },
       {drogon::Post});

--- a/apps/server/src/runtime_state.hpp
+++ b/apps/server/src/runtime_state.hpp
@@ -42,8 +42,14 @@ class RuntimeState {
   std::optional<std::string> reset_chat(std::string &error_code,
                                         std::string &error_message);
 
+  std::optional<zoo::Response> chat_stream(const std::string &message,
+                                           std::function<void(std::string_view)> token_callback,
+                                           std::string &error_code,
+                                           std::string &error_message);
+
  private:
   mutable std::mutex mu_;
+  mutable std::mutex agent_mu_;  // Serializes agent operations (chat, reset)
   std::unordered_map<std::string, ModelEntry> models_;
   std::optional<std::string> active_model_id_;
   std::shared_ptr<zoo::Agent> agent_;


### PR DESCRIPTION
## Summary

Addresses all actionable items from `ProjectEvaluation.md`:

- **Concurrency data race (Issue 1 — High):** Added `agent_mu_` mutex to `RuntimeState` that serializes `chat_complete()`, `chat_stream()`, and `reset_chat()` for the full duration of each agent operation (including `future.get()`). Prevents concurrent HTTP requests from interleaving chat history or racing a reset against an in-flight inference.

- **SSE streaming (Issue 2 — High):** Added `POST /api/chat/stream` using Drogon's `newAsyncStreamResponse`. Token callbacks from `zoo::Agent::chat()` are piped as `text/event-stream` SSE events (`type: token | done | error`). Inference runs on a detached thread so Drogon's I/O loop is not blocked. The frontend's Send button now uses a `fetch` + `ReadableStream` SSE client that appends tokens incrementally, with a blinking cursor and pulsing streaming indicator while in progress.

- **`sanitize_model_id` O(N²) → O(N) (Issue 3 — Medium):** Replaced the repeated `erase(begin())` loop with a single `find_first_not_of` / `find_last_not_of` + `substr` pass.

- **Real-time model sync (Issue 4 — Low/Medium):** Added a `setInterval` (5 s) in the Svelte frontend that silently refreshes the model list when the UI is not busy.

**Issue 5 (global state)** was intentionally skipped — the evaluation itself notes it is acceptable for the MVP tool scope and does not affect correctness.

## Test plan

- [ ] `cmake --build build -j` compiles cleanly (no new warnings)
- [ ] `ctest --test-dir build --output-on-failure` passes all existing tests
- [ ] Register a GGUF model, load it, and send a message — verify tokens appear incrementally in the UI as they are generated
- [ ] While a stream is in progress, a second POST to `/api/chat/stream` blocks until the first completes (serialized by `agent_mu_`)
- [ ] `POST /api/chat/reset` while a stream is active returns after the stream finishes
- [ ] Model list auto-refreshes every 5 s without user interaction

🤖 Generated with [Claude Code](https://claude.ai/claude-code)